### PR TITLE
Bump serve-static and express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5253,9 +5253,9 @@
 			"dev": true
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+			"integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
 			"dev": true,
 			"dependencies": {
 				"bytes": "3.1.2",
@@ -5266,7 +5266,7 @@
 				"http-errors": "2.0.0",
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
-				"qs": "6.11.0",
+				"qs": "6.13.0",
 				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
@@ -5504,14 +5504,19 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
 			"dev": true,
 			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.1",
-				"set-function-length": "^1.1.1"
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -6192,17 +6197,20 @@
 			}
 		},
 		"node_modules/define-data-property": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.2.1",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/define-properties": {
@@ -6729,9 +6737,9 @@
 			"dev": true
 		},
 		"node_modules/encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
@@ -6833,6 +6841,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es-iterator-helpers": {
@@ -7804,37 +7833,37 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.19.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-			"integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+			"integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.2",
+				"body-parser": "1.20.3",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "0.6.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.2.0",
+				"finalhandler": "1.3.1",
 				"fresh": "0.5.2",
 				"http-errors": "2.0.0",
-				"merge-descriptors": "1.0.1",
+				"merge-descriptors": "1.0.3",
 				"methods": "~1.1.2",
 				"on-finished": "2.4.1",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
+				"path-to-regexp": "0.1.10",
 				"proxy-addr": "~2.0.7",
-				"qs": "6.11.0",
+				"qs": "6.13.0",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
-				"send": "0.18.0",
-				"serve-static": "1.15.0",
+				"send": "0.19.0",
+				"serve-static": "1.16.2",
 				"setprototypeof": "1.2.0",
 				"statuses": "2.0.1",
 				"type-is": "~1.6.18",
@@ -7968,13 +7997,13 @@
 			}
 		},
 		"node_modules/finalhandler": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-			"integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+			"integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
 			"dev": true,
 			"dependencies": {
 				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"on-finished": "2.4.1",
 				"parseurl": "~1.3.3",
@@ -8244,15 +8273,19 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
 			"dev": true,
 			"dependencies": {
+				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
 				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -8517,12 +8550,12 @@
 			}
 		},
 		"node_modules/has-property-descriptors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.1.1"
+				"es-define-property": "^1.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -10049,10 +10082,13 @@
 			}
 		},
 		"node_modules/merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-			"dev": true
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+			"integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
@@ -11992,9 +12028,9 @@
 			}
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+			"integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
 			"dev": true
 		},
 		"node_modules/path-type": {
@@ -12645,12 +12681,12 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
 			"dev": true,
 			"dependencies": {
-				"side-channel": "^1.0.4"
+				"side-channel": "^1.0.6"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -13711,9 +13747,9 @@
 			}
 		},
 		"node_modules/send": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-			"integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+			"integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
 			"dev": true,
 			"dependencies": {
 				"debug": "2.6.9",
@@ -13749,6 +13785,15 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
 		},
+		"node_modules/send/node_modules/encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/send/node_modules/mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -13768,15 +13813,15 @@
 			"dev": true
 		},
 		"node_modules/serve-static": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-			"integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+			"integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
 			"dev": true,
 			"dependencies": {
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "0.18.0"
+				"send": "0.19.0"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -13788,15 +13833,17 @@
 			"integrity": "sha512-lXLOiqpkUumhRdFF3k1osNXCy9akgx/dyPZ5p8qAg9seJzXr5ZrlqZuWIMuY6ejOsVLE6flJ5/h3lsn57fQ/PQ=="
 		},
 		"node_modules/set-function-length": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"dev": true,
 			"dependencies": {
-				"define-data-property": "^1.1.1",
-				"get-intrinsic": "^1.2.1",
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"has-property-descriptors": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13861,14 +13908,18 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.0",
-				"get-intrinsic": "^1.0.2",
-				"object-inspect": "^1.9.0"
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -19809,9 +19860,9 @@
 			"dev": true
 		},
 		"body-parser": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+			"integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
 			"dev": true,
 			"requires": {
 				"bytes": "3.1.2",
@@ -19822,7 +19873,7 @@
 				"http-errors": "2.0.0",
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
-				"qs": "6.11.0",
+				"qs": "6.13.0",
 				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
@@ -19996,14 +20047,16 @@
 			}
 		},
 		"call-bind": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
 			"dev": true,
 			"requires": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.1",
-				"set-function-length": "^1.1.1"
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
 			}
 		},
 		"callsites": {
@@ -20476,14 +20529,14 @@
 			}
 		},
 		"define-data-property": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"dev": true,
 			"requires": {
-				"get-intrinsic": "^1.2.1",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
 			}
 		},
 		"define-properties": {
@@ -20796,9 +20849,9 @@
 			"dev": true
 		},
 		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
 			"dev": true
 		},
 		"end-of-stream": {
@@ -20889,6 +20942,21 @@
 				"unbox-primitive": "^1.0.2",
 				"which-typed-array": "^1.1.13"
 			}
+		},
+		"es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.2.4"
+			}
+		},
+		"es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true
 		},
 		"es-iterator-helpers": {
 			"version": "1.0.15",
@@ -21608,37 +21676,37 @@
 			"devOptional": true
 		},
 		"express": {
-			"version": "4.19.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-			"integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+			"integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
 			"dev": true,
 			"requires": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.2",
+				"body-parser": "1.20.3",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "0.6.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.2.0",
+				"finalhandler": "1.3.1",
 				"fresh": "0.5.2",
 				"http-errors": "2.0.0",
-				"merge-descriptors": "1.0.1",
+				"merge-descriptors": "1.0.3",
 				"methods": "~1.1.2",
 				"on-finished": "2.4.1",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
+				"path-to-regexp": "0.1.10",
 				"proxy-addr": "~2.0.7",
-				"qs": "6.11.0",
+				"qs": "6.13.0",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
-				"send": "0.18.0",
-				"serve-static": "1.15.0",
+				"send": "0.19.0",
+				"serve-static": "1.16.2",
 				"setprototypeof": "1.2.0",
 				"statuses": "2.0.1",
 				"type-is": "~1.6.18",
@@ -21758,13 +21826,13 @@
 			}
 		},
 		"finalhandler": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-			"integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+			"integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"on-finished": "2.4.1",
 				"parseurl": "~1.3.3",
@@ -21966,11 +22034,12 @@
 			"dev": true
 		},
 		"get-intrinsic": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
 			"dev": true,
 			"requires": {
+				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
@@ -22166,12 +22235,12 @@
 			"dev": true
 		},
 		"has-property-descriptors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dev": true,
 			"requires": {
-				"get-intrinsic": "^1.1.1"
+				"es-define-property": "^1.0.0"
 			}
 		},
 		"has-proto": {
@@ -23278,9 +23347,9 @@
 			}
 		},
 		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+			"integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
 			"dev": true
 		},
 		"merge-stream": {
@@ -24622,9 +24691,9 @@
 			}
 		},
 		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+			"integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
 			"dev": true
 		},
 		"path-type": {
@@ -25069,12 +25138,12 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
 			"dev": true,
 			"requires": {
-				"side-channel": "^1.0.4"
+				"side-channel": "^1.0.6"
 			}
 		},
 		"querystringify": {
@@ -25825,9 +25894,9 @@
 			}
 		},
 		"send": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-			"integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+			"integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -25862,6 +25931,12 @@
 						}
 					}
 				},
+				"encodeurl": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+					"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+					"dev": true
+				},
 				"mime": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -25877,15 +25952,15 @@
 			}
 		},
 		"serve-static": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-			"integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+			"integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
 			"dev": true,
 			"requires": {
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "0.18.0"
+				"send": "0.19.0"
 			}
 		},
 		"set-cookie-parser": {
@@ -25894,15 +25969,17 @@
 			"integrity": "sha512-lXLOiqpkUumhRdFF3k1osNXCy9akgx/dyPZ5p8qAg9seJzXr5ZrlqZuWIMuY6ejOsVLE6flJ5/h3lsn57fQ/PQ=="
 		},
 		"set-function-length": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"dev": true,
 			"requires": {
-				"define-data-property": "^1.1.1",
-				"get-intrinsic": "^1.2.1",
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"has-property-descriptors": "^1.0.2"
 			}
 		},
 		"set-function-name": {
@@ -25949,14 +26026,15 @@
 			"dev": true
 		},
 		"side-channel": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0",
-				"get-intrinsic": "^1.0.2",
-				"object-inspect": "^1.9.0"
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
 			}
 		},
 		"siginfo": {


### PR DESCRIPTION
Bumps [serve-static](https://github.com/expressjs/serve-static) and [express](https://github.com/expressjs/express). These dependencies needed to be updated together.

Updates `serve-static` from 1.15.0 to 1.16.2
- [Release notes](https://github.com/expressjs/serve-static/releases)
- [Changelog](https://github.com/expressjs/serve-static/blob/v1.16.2/HISTORY.md)
- [Commits](https://github.com/expressjs/serve-static/compare/v1.15.0...v1.16.2)

Updates `express` from 4.19.2 to 4.21.0
- [Release notes](https://github.com/expressjs/express/releases)
- [Changelog](https://github.com/expressjs/express/blob/4.21.0/History.md)
- [Commits](https://github.com/expressjs/express/compare/4.19.2...4.21.0)

---
updated-dependencies:
- dependency-name: serve-static dependency-type: indirect
- dependency-name: express dependency-type: indirect ...